### PR TITLE
[Example] Improving base station menu

### DIFF
--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -29,8 +29,8 @@ message(STATUS "Building GPS Drivers")
 
 CPMAddPackage(
     NAME px4-gpsdrivers
-    GITHUB_REPOSITORY Louis-max-H/PX4-GPSDrivers
-    GIT_TAG pr-base-main
+    GITHUB_REPOSITORY PX4/PX4-GPSDrivers
+    GIT_TAG main
     SOURCE_SUBDIR src
 )
 

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -29,8 +29,8 @@ message(STATUS "Building GPS Drivers")
 
 CPMAddPackage(
     NAME px4-gpsdrivers
-    GITHUB_REPOSITORY PX4/PX4-GPSDrivers
-    GIT_TAG main
+    GITHUB_REPOSITORY Louis-max-H/PX4-GPSDrivers
+    GIT_TAG pr-base-main
     SOURCE_SUBDIR src
 )
 

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -234,7 +234,6 @@ GPSBaseStationSupport *GPSProvider::_connectGPS()
     }
 
     gpsDriver->setBaseGeneralConfig(_rtkData.protocol);
-    qDebug() << "Set protocol to : " << _rtkData.protocol;
 
     switch(_rtkData.baseMode){
         case 1:
@@ -246,7 +245,7 @@ GPSBaseStationSupport *GPSProvider::_connectGPS()
             gpsDriver->setSurveyInSpecs(_rtkData.surveyInAccMeters * 10000.f, _rtkData.surveyInDurationSecs);
             break;
     }
-    
+
     _gpsConfig.output_mode = GPSHelper::OutputMode::RTCM;
 
     if (gpsDriver->configure(baudrate, _gpsConfig) != 0) {

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -233,12 +233,20 @@ GPSBaseStationSupport *GPSProvider::_connectGPS()
         return nullptr;
     }
 
-    gpsDriver->setSurveyInSpecs(_rtkData.surveyInAccMeters * 10000.f, _rtkData.surveyInDurationSecs);
+    gpsDriver->setBaseGeneralConfig(_rtkData.protocol);
+    qDebug() << "Set protocol to : " << _rtkData.protocol;
 
-    if (_rtkData.useFixedBaseLoction) {
-        gpsDriver->setBasePosition(_rtkData.fixedBaseLatitude, _rtkData.fixedBaseLongitude, _rtkData.fixedBaseAltitudeMeters, _rtkData.fixedBaseAccuracyMeters * 1000.0f);
+    switch(_rtkData.baseMode){
+        case 1:
+            gpsDriver->setBasePosition(_rtkData.fixedBaseLatitude, _rtkData.fixedBaseLongitude, _rtkData.fixedBaseAltitudeMeters, _rtkData.fixedBaseAccuracyMeters * 1000.0f);
+            break;
+
+        case 0:
+        default:
+            gpsDriver->setSurveyInSpecs(_rtkData.surveyInAccMeters * 10000.f, _rtkData.surveyInDurationSecs);
+            break;
     }
-
+    
     _gpsConfig.output_mode = GPSHelper::OutputMode::RTCM;
 
     if (gpsDriver->configure(baudrate, _gpsConfig) != 0) {

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -42,7 +42,8 @@ public:
     struct rtk_data_s {
         double surveyInAccMeters = 0;
         int surveyInDurationSecs = 0;
-        bool useFixedBaseLoction = false;
+        int baseMode = 0;
+        int protocol = 0;
         double fixedBaseLatitude = 0.;
         double fixedBaseLongitude = 0.;
         float fixedBaseAltitudeMeters = 0.f;

--- a/src/GPS/GPSRtk.cc
+++ b/src/GPS/GPSRtk.cc
@@ -62,28 +62,37 @@ void GPSRtk::_onGPSSurveyInStatus(float duration, float accuracyMM,  double lati
 void GPSRtk::connectGPS(const QString &device, QStringView gps_type)
 {
     GPSProvider::GPSType type;
+    RTKSettings* rtkSettings = SettingsManager::instance()->rtkSettings();
+    
     if (gps_type.contains(QStringLiteral("trimble"), Qt::CaseInsensitive)) {
         type = GPSProvider::GPSType::trimble;
+        rtkSettings->baseReceiverManufacturers()->setRawValue(3);
         qCDebug(GPSRtkLog) << "Connecting Trimble device";
+
     } else if (gps_type.contains(QStringLiteral("septentrio"), Qt::CaseInsensitive)) {
         type = GPSProvider::GPSType::septentrio;
+        rtkSettings->baseReceiverManufacturers()->setRawValue(5);
         qCDebug(GPSRtkLog) << "Connecting Septentrio device";
+
     } else if (gps_type.contains(QStringLiteral("femtomes"), Qt::CaseInsensitive)) {
         type = GPSProvider::GPSType::femto;
+        rtkSettings->baseReceiverManufacturers()->setRawValue(9);
         qCDebug(GPSRtkLog) << "Connecting Femtomes device";
+
     } else {
         type = GPSProvider::GPSType::u_blox;
+        rtkSettings->baseReceiverManufacturers()->setRawValue(17);
         qCDebug(GPSRtkLog) << "Connecting U-blox device";
     }
 
     disconnectGPS();
 
-    RTKSettings* const rtkSettings = SettingsManager::instance()->rtkSettings();
     _requestGpsStop = false;
     const GPSProvider::rtk_data_s rtkData = {
         rtkSettings->surveyInAccuracyLimit()->rawValue().toDouble(),
         rtkSettings->surveyInMinObservationDuration()->rawValue().toInt(),
-        rtkSettings->useFixedBasePosition()->rawValue().toBool(),
+        rtkSettings->baseMode()->rawValue().toInt(),
+        rtkSettings->protocol()->rawValue().toInt(),
         rtkSettings->fixedBasePositionLatitude()->rawValue().toDouble(),
         rtkSettings->fixedBasePositionLongitude()->rawValue().toDouble(),
         rtkSettings->fixedBasePositionAltitude()->rawValue().toFloat(),

--- a/src/Settings/RTK.SettingsGroup.json
+++ b/src/Settings/RTK.SettingsGroup.json
@@ -4,6 +4,22 @@
     "QGC.MetaData.Facts":
 [
 {
+    "name":                 "baseReceiverManufacturers",
+    "shortDesc":            "GPS manufacturers for settings",
+    "type":                 "uint8",
+    "enumStrings":          "Standard,All,Trimble,Septentrio,Femtomes,UBlox",
+    "enumValues":           "1,31,3,5,9,17",
+    "default":              31
+},
+{
+    "name":                 "protocol",
+    "shortDesc":            "RTK protocol used by the receiver",
+    "type":                 "uint8",
+    "enumStrings":          "RTCMv3,RTCMv2,CRM",
+    "enumValues":           "0,1,2",
+    "default":              0
+},
+{
     "name":                 "surveyInAccuracyLimit",
     "shortDesc":            "Survey in accuracy (U-blox only)",
     "longDesc":             "The minimum accuracy value that Survey-In must achieve before it can complete.",
@@ -30,19 +46,19 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "useFixedBasePosition",
-    "shortDesc":     "Use specified base position",
-    "longDesc":      "Specify the values for the RTK base position without having to do a survey in.",
-    "type":                 "bool",
-    "default":         false,
+    "name":                 "baseMode",
+    "shortDesc":            "Use specified base mode",
+    "longDesc":             "Specify the mode for the RTK base 0: Survey-In (Fixed + Auto) 1: Specify position (Fixed + Manual)",
+    "type":                 "uint8",
+    "default":              0,
     "qgcRebootRequired":    true
 },
 {
     "name":                 "fixedBasePositionLatitude",
-    "shortDesc":     "Base Position Latitude",
-    "longDesc":      "Defines the latitude of the fixed RTK base position.",
+    "shortDesc":            "Base Position Latitude",
+    "longDesc":             "Defines the latitude of the fixed RTK base position.",
     "type":                 "double",
-    "default":         0,
+    "default":              0,
     "min":                  -90,
     "max":                  90,
     "decimalPlaces":        9,

--- a/src/Settings/RTKSettings.cc
+++ b/src/Settings/RTKSettings.cc
@@ -16,9 +16,11 @@ DECLARE_SETTINGGROUP(RTK, "RTK")
     qmlRegisterUncreatableType<RTKSettings>("QGroundControl.SettingsManager", 1, 0, "RTKSettings", "Reference only"); \
 }
 
+DECLARE_SETTINGSFACT(RTKSettings, baseReceiverManufacturers)
+DECLARE_SETTINGSFACT(RTKSettings, protocol)
 DECLARE_SETTINGSFACT(RTKSettings, surveyInAccuracyLimit)
 DECLARE_SETTINGSFACT(RTKSettings, surveyInMinObservationDuration)
-DECLARE_SETTINGSFACT(RTKSettings, useFixedBasePosition)
+DECLARE_SETTINGSFACT(RTKSettings, baseMode)
 DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionLatitude)
 DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionLongitude)
 DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionAltitude)

--- a/src/Settings/RTKSettings.h
+++ b/src/Settings/RTKSettings.h
@@ -17,9 +17,11 @@ class RTKSettings : public SettingsGroup
 public:
     RTKSettings(QObject* parent = nullptr);
     DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(baseReceiverManufacturers)
+    DEFINE_SETTINGFACT(protocol)
     DEFINE_SETTINGFACT(surveyInAccuracyLimit)
     DEFINE_SETTINGFACT(surveyInMinObservationDuration)
-    DEFINE_SETTINGFACT(useFixedBasePosition)
+    DEFINE_SETTINGFACT(baseMode)
     DEFINE_SETTINGFACT(fixedBasePositionLatitude)
     DEFINE_SETTINGFACT(fixedBasePositionLongitude)
     DEFINE_SETTINGFACT(fixedBasePositionAltitude)

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -52,7 +52,7 @@ ToolIndicatorPage {
 
     onManufacturerChanged: {
         console.log("Manufacturer changed in QML to:", manufacturer)
-        if (!(manufacturer & _septentrio) ){
+        if (!(manufacturer & _septentrio) && baseMode == 3){
             baseMode = 1
         }
     }
@@ -173,7 +173,7 @@ ToolIndicatorPage {
             RowLayout {
                 QGCRadioButton {
                     text:       qsTr("Survey-In")
-                    checked:    baseMode == 1
+                    checked:    baseMode == 0
                     onClicked:  {
                         console.log("ManufacturerR: ", manufacturer)
                         return (rtkSettings.baseMode.rawValue = 1)
@@ -183,7 +183,7 @@ ToolIndicatorPage {
 
                 QGCRadioButton {
                     text: qsTr("Specify position")
-                    checked:    baseMode == 2
+                    checked:    baseMode == 1
                     onClicked:  rtkSettings.baseMode.rawValue = 2
                     visible:    manufacturer & _standard
                 }

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -52,30 +52,9 @@ ToolIndicatorPage {
 
     onManufacturerChanged: {
         console.log("Manufacturer changed in QML to:", manufacturer)
-        if (!(manufacturer & _septentrio) && baseMode == 3){
+        if (!(manufacturer & _septentrio) ){
             baseMode = 1
         }
-    }
-
-    function errorText() {
-        if(!_activeVehicle || !_activeVehicle.gps){
-            return qsTr("Disconnected")
-        } else if (_activeVehicle.gps.systemErrors.value === 1) {
-            return qsTr("Incoming correction")
-        } else if (_activeVehicle.gps.systemErrors.value === 2) {
-            return qsTr("Configuration")
-        } else if (_activeVehicle.gps.systemErrors.value === 4) {
-            return qsTr("Software")
-        } else if (_activeVehicle.gps.systemErrors.value === 8) {
-            return qsTr("Antenna")
-        } else if (_activeVehicle.gps.systemErrors.value === 16) {
-            return qsTr("Event congestion")
-        } else if (_activeVehicle.gps.systemErrors.value === 32) {
-            return qsTr("CPU overload")
-        } else if (_activeVehicle.gps.systemErrors.value === 64) {
-            return qsTr("Output congestion")
-        }
-        return "Multiple errors"
     }
 
     contentComponent: Component {

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -173,14 +173,14 @@ ToolIndicatorPage {
                 QGCRadioButton {
                     text:       qsTr("Survey-In")
                     checked:    baseMode == 0
-                    onClicked:  rtkSettings.baseMode.rawValue = 1
+                    onClicked:  rtkSettings.baseMode.rawValue = 0
                     visible:    manufacturer & _standard
                 }
 
                 QGCRadioButton {
                     text: qsTr("Specify position")
                     checked:    baseMode == 1
-                    onClicked:  rtkSettings.baseMode.rawValue = 2
+                    onClicked:  rtkSettings.baseMode.rawValue = 1
                     visible:    manufacturer & _standard
                 }
             }

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -46,7 +46,7 @@ ToolIndicatorPage {
      * If you want to display :
      * All settings      : 0b11111 (31)
      * Standard settings : 0b00001 ( 1)
-     * Only Trimble      : 0b00011 ( 3) = Standard + Trimble
+     * Only Trimble      : 0b00011 ( 3) = Standard | Trimble
      * Etc ...
     */
 
@@ -207,7 +207,7 @@ ToolIndicatorPage {
                 visible:                ( 
                     baseMode == 1
                     && rtkSettings.surveyInMinObservationDuration.visible
-                    && (manufacturer & _standard)
+                    && (manufacturer & (_ublox | _femtomes | _trimble))
                 )
             }
 

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -51,8 +51,7 @@ ToolIndicatorPage {
     */
 
     onManufacturerChanged: {
-        console.log("Manufacturer changed in QML to:", manufacturer)
-        if (!(manufacturer & _septentrio) && baseMode == 3){
+        if (baseMode == 3 && !(manufacturer & _septentrio)){
             baseMode = 1
         }
     }
@@ -174,10 +173,7 @@ ToolIndicatorPage {
                 QGCRadioButton {
                     text:       qsTr("Survey-In")
                     checked:    baseMode == 0
-                    onClicked:  {
-                        console.log("ManufacturerR: ", manufacturer)
-                        return (rtkSettings.baseMode.rawValue = 1)
-                    }
+                    onClicked:  rtkSettings.baseMode.rawValue = 1
                     visible:    manufacturer & _standard
                 }
 

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -167,11 +167,13 @@ ToolIndicatorPage {
             }
 
             RowLayout {
+                visible:    manufacturer & _septentrio
+
                 QGCRadioButton {
                     text:       qsTr("RTCMv3")
                     checked:    rtkSettings.protocol.rawValue  == 0
                     onClicked:  rtkSettings.protocol.rawValue = 0
-                    visible:    true
+                    visible:    manufacturer & _septentrio
                 }
 
                 QGCRadioButton {
@@ -186,9 +188,7 @@ ToolIndicatorPage {
                     checked:    rtkSettings.protocol.rawValue  == 2
                     onClicked:  rtkSettings.protocol.rawValue  = 2
                     visible:    manufacturer & _septentrio
-                }
-
-                visible:        true
+                }                
             }
 
             RowLayout {
@@ -196,7 +196,7 @@ ToolIndicatorPage {
                     text:       qsTr("Survey-In")
                     checked:    baseMode == 1
                     onClicked:  {
-                        console.log("Manufacturer: ", manufacturer)
+                        console.log("ManufacturerR: ", manufacturer)
                         return (rtkSettings.baseMode.rawValue = 1)
                     }
                     visible:    manufacturer & _standard

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -192,7 +192,7 @@ ToolIndicatorPage {
                 fact:                   QGroundControl.settingsManager.rtkSettings.surveyInAccuracyLimit
                 majorTickStepSize:      0.1
                 visible:                (
-                    baseMode == 1
+                    baseMode == 0
                     && rtkSettings.surveyInAccuracyLimit.visible
                     && (manufacturer & _ublox)
                 )
@@ -205,7 +205,7 @@ ToolIndicatorPage {
                 fact:                   rtkSettings.surveyInMinObservationDuration
                 majorTickStepSize:      10
                 visible:                ( 
-                    baseMode == 1
+                    baseMode == 0
                     && rtkSettings.surveyInMinObservationDuration.visible
                     && (manufacturer & (_ublox | _femtomes | _trimble))
                 )
@@ -215,7 +215,7 @@ ToolIndicatorPage {
                 label:                  rtkSettings.fixedBasePositionLatitude.shortDescription
                 fact:                   rtkSettings.fixedBasePositionLatitude
                 visible:                (
-                    baseMode == 2 
+                    baseMode == 1
                     && (manufacturer & _standard)
                 )
             }
@@ -224,7 +224,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionLongitude.shortDescription
                 fact:               rtkSettings.fixedBasePositionLongitude
                 visible:            (
-                    baseMode == 2 
+                    baseMode == 1
                     && (manufacturer & _standard)
                 )
             }
@@ -233,7 +233,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionAltitude.shortDescription
                 fact:               rtkSettings.fixedBasePositionAltitude
                 visible:            (
-                    baseMode == 2
+                    baseMode == 1
                     && (manufacturer & _standard)
                 )
             }
@@ -242,7 +242,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionAccuracy.shortDescription
                 fact:               rtkSettings.fixedBasePositionAccuracy
                 visible:            (
-                    baseMode == 2
+                    baseMode == 1
                     && (manufacturer & _ublox)
                 )
             }
@@ -250,7 +250,7 @@ ToolIndicatorPage {
             LabelledButton {
                 label:              qsTr("Current Base Position")
                 buttonText:         enabled ? qsTr("Save") : qsTr("Not Yet Valid")
-                visible:            baseMode == 2
+                visible:            baseMode == 1
                 enabled:            QGroundControl.gpsRtk.valid.value
 
                 onClicked: {


### PR DESCRIPTION
Example PR 


Hi :wave:

This PR aim to develop base station menu and depend on this PR : [To update] https://github.com/Louis-max-H/PX4-GPSDrivers/pull/3

Description
-----------

UBlox menu | Septentrio menu             |  Manufacturer list
:-------------------------:|:-------------------------: | :---: 
![](https://imgur.com/iR8IdIk.png) | ![](https://i.imgur.com/fnYAx7w.png)  |  ![](https://i.imgur.com/NZzPxcP.png)

1) Proposing different settings according to receiver manufacturer
2) Base Station mode change from bool to int. That will allow a future PR that have base station (for example, moving base station on boat)
3) Implement base station menu for Septentrio (base infos, base config)

### Explanation.
1) Manufacturer allow the hide and show of some settings to keep only theses that are implemented.
We use bit mask defined like this :
```
    readonly property var    _standard:           0b00001
    readonly property var    _trimble:            0b00010
    readonly property var    _septentrio:         0b00100
    readonly property var    _femtomes:           0b01000
    readonly property var    _ublox:              0b10000
```

To restrict a parameters' visibility to U-Blox + Septentrio : (You can use either | or +)
```
visible:    manufacturer & (_ublox | _septentrio)
```
If implemented by all manufacturer :
```
visible:    manufacturer & _standard
```
This parameter is always visible because it is implemented by everyone, but I think that specifying it each time avoids uncertainties such as, how compatible is this parameter with the receiver? Has the developer thought this through?
Don't hesitate to tell me what you think :)

To show parameters available for U-blox, set manufacturer to `_standard + _ublox`
Manufacturer is set automatically when plugin a receiver.

2) Base station mode is now :
0 : Survey-in
1 : Fixed
This change is compatible with the 4 different drivers that use BaseSettingsType (base_station.h).

3)
a) Base stations info is display by using PosGeodetic information.
b) Some parameters like Ublox min precision don't have an equivalent in Septentrio, here is a quick recap of with parameters is available or not :


| Parameters​       |                   | Ublox​ | Septentrio​ | Femtomes​ | Trimble​ |
| -----------------|------------------ | :----------:| :-----------: | :---------: | :--------: |
| Survey-in (auto)​ | Min duration​      | ✅          | ​        | ✅​       | ✅​ |
| ​                 | Min precision​     | ✅​          |         | ​       | ​ |
| Specify location​ | Long, Lat, Alt​    | ✅​          | ✅​        | ✅​       | ✅​ |
| ​                 | Base precision​    | ✅​          | ​        | ​       | ​ |
| ​                 | Set from position​ | ✅​          | ✅​        | ✅​       | ✅​ |

Survey-in is available for Septentrio but this option is not configurable.

Test Steps
-----------
I have followed this procedure and another intern (@Duck) have done the same on another computer.
```bash
git clone https://github.com/Louis-max-H/qgroundcontrol
cd qgroundcontrol
git checkout pr-base-master
git submodule update --init --force --recursive
chmod +x tools/setup/*.sh
docker build --file ./deploy/docker/Dockerfile-build-ubuntu -t qgc-linux-docker .
```
Edit the file src/GPS/CMakeLists.txt
To have
```
CPMAddPackage(
    NAME px4-gpsdrivers
    GITHUB_REPOSITORY Louis-max-H/PX4-GPSDrivers
    GIT_TAG pr-base-station
    SOURCE_SUBDIR src
)
```
Instead of :
```
CPMAddPackage(
    NAME px4-gpsdrivers
    GITHUB_REPOSITORY PX4/PX4-GPSDrivers
    GIT_TAG main
    SOURCE_SUBDIR src
)
```
You can now build QGC using :
```
docker run --privileged --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build qgc-linux-docker
./build/AppDir/AppRun
```

- Unplug all
- Plug CubeOrangePlus
- Select a different manufacturer than the board tested
- Select the config you want to test
- Plug base station
- See if :
    - Precision is improved
    - Information are displayed
    - Manufacturer is automaticaly set

Do these steps for Survey-In, Set location and for each protocol (Septentrio)
Test have been made on Ublox and Septentrio, I don't have the equipment to test other GPS systems but they should work has Ublox does.

Checklist:
----------
- [x ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ x] I have tested my changes.


Please let me know if I need to make any changes to this RP so that it can be accepted by the community, this would be my first PR :partying_face: 


Ps: The automatic tests should fail because of the need to modify the Makefile, so I'm putting the PR in draft form and I'll come back to you once the PR for the GPS driver has been accepted.
